### PR TITLE
Attempt to check PipeWire version at runtime

### DIFF
--- a/com.github.wwmm.easyeffects.yml
+++ b/com.github.wwmm.easyeffects.yml
@@ -6,7 +6,7 @@ id: com.github.wwmm.easyeffects
 runtime: org.gnome.Platform
 runtime-version: '40'
 sdk: org.gnome.Sdk
-command: easyeffects
+command: easyeffects-wrapper
 rename-icon: easyeffects
 finish-args:
   - --share=ipc
@@ -67,13 +67,18 @@ modules:
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+)
+      - type: file
+        path: easyeffects-wrapper.sh
       - type: patch
         path: patch/easyeffects/001-fix-about-page-icon.patch
+      - type: patch
+        path: patch/easyeffects/002-fix-desktop-file.patch
+      - type: shell
+        commands:
+          - install -Dvm 755 easyeffects-wrapper.sh $FLATPAK_DEST/bin/easyeffects-wrapper
     post-install:
-      - install -Dm644 -t $FLATPAK_DEST/share/licenses/com.github.wwmm.easyeffects
-        ../LICENSE.md
-      - mkdir -pm755 /app/extensions/Plugins
-
+      - install -Dm644 -t $FLATPAK_DEST/share/licenses/$FLATPAK_ID ../LICENSE.md
+      - mkdir -pm755 $FLATPAK_DEST/extensions/Plugins
     modules:
       # Since easyeffects 6.0.0 need meson 0.57 or newer, and the gnome 40 runtime has an older one. 
       # When the gnome 41 runtime is released this can be removed, as well as PYTHONPATH from above.
@@ -323,6 +328,7 @@ modules:
           - /share/doc/rnnoise
 
       # Easyeffects 6.0.0 depends on pipewire >=0.3.31, gnome 40 runtime has 0.3.25
+      # Ensure to update easyeffects-wrapper.sh when updating pipewire version.
       - name: pipewire
         buildsystem: meson
         config-opts:

--- a/easyeffects-wrapper.sh
+++ b/easyeffects-wrapper.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# this checks the PipeWire version on the host, and then compares it to what we need.
+# current baseline to compile EasyEffects is 0.3.31, thus the host needs minimum that as well.
+
+# get host's PipeWire version:
+
+# https://stackoverflow.com/a/48066872
+# we can't use jq to parse JSON as that will fail to run with flatpak run or from desktop file; gives "command not found", even though jq is in the runtime/sdk.
+found_pipewire_version="$(pw-dump | grep -Po '"version":.*?[^\\]",' |  sed 's/"//g' | sed 's/://g' | sed 's/,//g' | cut -c9-18)"
+
+required_pipewire_version="0.3.31" # from EasyEffects' build requirements
+
+# compare versions
+# from https://unix.stackexchange.com/a/285928
+
+if [ "$(printf '%s\n' "$required_pipewire_version" "$found_pipewire_version" | sort -V | head -n1)" = "$required_pipewire_version" ]; then 
+      echo "You have PipeWire ${found_pipewire_version} installed"
+      echo "This is newer or the same as PipeWire ${required_pipewire_version} required to run EasyEffects"
+
+else
+
+  if pw-dump >/dev/null ; then # TRY
+      # https://stackoverflow.com/a/6852427
+      # https://stackoverflow.com/a/428118
+      echo "pw-dump succeeded; system likely has PipeWire 0.3.x or later."
+      echo "You have PipeWire ${found_pipewire_version} installed"
+      echo "This is less than PipeWire ${required_pipewire_version} required to run EasyEffects"
+
+      # put all the text here so we can use variable as part of output, it is helpful to the user.
+      zenity --info --title="PipeWire version warning" --no-wrap \
+        --text="Could not find compatible PipeWire.
+Install PipeWire ${required_pipewire_version} or newer for EasyEffects to work correctly. \n
+More info:
+PipeWire ${found_pipewire_version} was found, which is not recent enough for EasyEffects. 
+If on Ubuntu or an Ubuntu-based system you may try https://pipewire-debian.github.io
+You may try PulseEffects which does not require PipeWire. \n
+If you believe this message was shown in error, please report it to: https://github.com/wwmm/easyeffects"
+      
+  else # CATCH
+      echo 'pw-dump failed; system likely has PipeWire 0.2.x or older, or no PipeWire package exists.'
+      echo "Your system does not appear to have PipeWire 0.3.0 or later installed"
+      echo "This is less than PipeWire ${required_pipewire_version} required to run EasyEffects"
+
+      # put all the text here so we can use variable as part of output, it is helpful to the user.
+      zenity --info --title="PipeWire version warning" --no-wrap \
+        --text="Could not find compatible PipeWire.
+Install PipeWire ${required_pipewire_version} or newer for EasyEffects to work correctly. \n
+More info:
+Either PipeWire is not installed or is not recent enough for EasyEffects. 
+If on Ubuntu or an Ubuntu-based system you may try https://pipewire-debian.github.io
+You may try PulseEffects which does not require PipeWire. \n
+If you believe this message was shown in error, please report it to: https://github.com/wwmm/easyeffects"
+      
+  fi
+
+fi
+
+# launch the normal app without checking again
+exec easyeffects "$@"

--- a/patch/easyeffects/002-fix-desktop-file.patch
+++ b/patch/easyeffects/002-fix-desktop-file.patch
@@ -1,0 +1,43 @@
+From 1eba69fef4c800289485bee3544660e9baa45de6 Mon Sep 17 00:00:00 2001
+From: Vincent Chernin <38842733+vchernin@users.noreply.github.com>
+Date: Thu, 26 Aug 2021 10:45:37 -0700
+Subject: [PATCH 1/2] Rename the Exec line to launch the wrapper script.
+This was the only way I could get a wrapper script to launch from using the app launcher (i.e. triggering the desktop file.)
+
+---
+ data/com.github.wwmm.easyeffects.desktop.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/data/com.github.wwmm.easyeffects.desktop.in b/data/com.github.wwmm.easyeffects.desktop.in
+index 69912196..8c210e53 100644
+--- a/data/com.github.wwmm.easyeffects.desktop.in
++++ b/data/com.github.wwmm.easyeffects.desktop.in
+@@ -4,7 +4,7 @@ GenericName=Equalizer, Compressor and Other Audio Effects
+ Comment=Audio Effects for PipeWire Applications
+ Keywords=limiter;compressor;reverberation;equalizer;autovolume;
+ Categories=GTK;AudioVideo;Audio;
+-Exec=easyeffects
++Exec=easyeffects-wrapper
+ # Translators: This is an icon name, don't translate!
+ Icon=easyeffects
+ StartupNotify=true
+
+From df4cc6bb435c9a4694c6a807154609e9af4fe65f Mon Sep 17 00:00:00 2001
+From: Vincent Chernin <38842733+vchernin@users.noreply.github.com>
+Date: Thu, 26 Aug 2021 10:46:01 -0700
+Subject: [PATCH 2/2] Update com.github.wwmm.easyeffects.service.in
+
+---
+ data/com.github.wwmm.easyeffects.service.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/data/com.github.wwmm.easyeffects.service.in b/data/com.github.wwmm.easyeffects.service.in
+index 0493f584..9e56bc6b 100644
+--- a/data/com.github.wwmm.easyeffects.service.in
++++ b/data/com.github.wwmm.easyeffects.service.in
+@@ -1,3 +1,3 @@
+ [D-BUS Service]
+ Name=com.github.wwmm.easyeffects
+-Exec=@bindir@/easyeffects --gapplication-service
++Exec=@bindir@/easyeffects-wrapper --gapplication-service
+


### PR DESCRIPTION
Fixes #8

~~This patches the EasyEffects build process to not build and install the desktop file, and instead opts to use a copied version here. Ensuring `DBusActivatable=true` is also removed, this means we can use a wrapper script with EasyEffects.~~

Creates a wrapper script and patches desktop and service file to launch it. 

This lets us give an outdated PipeWire warning no matter how the app is launched. This is external to EasyEffects, so even if the app fails to launch the script will work.

Todo:
- [x] [This test build](https://github.com/flathub/com.github.wwmm.easyeffects/pull/2#issuecomment-906693140) includes unecessary debug warning dialog, debug dialog removed in [this latest build (use the highest number build)](https://github.com/flathub/com.github.wwmm.easyeffects/pull/2#issuecomment-906718699).
- [x] Investigate if there could be an easier way of fixing this without patching to remove the upstream desktop file, and copying over the desktop file with `DBusActivatable=true` removed. Even if not easily possible, that should still be the solution so it doesn't have to manually update it every now and then.
- [x] Confirm warning message is suitable.
- [x] Test on distros with PipeWire 0.2, <0.3.31, and no PipeWire (the debug build will be helpful here).
- [x] Fix typo in commit message.
- [x] Verify no significant delay (there isn't). 

Future PR :
- Mention `xdg-desktop-portal-gtk` which is necessary for a good experience on KDE. This functionality makes some sense to have in Flatpak as the portal issue is mainly only relevant to Flatpak. It should also mention bugs like https://github.com/flatpak/xdg-desktop-portal/issues/619.
- Maybe get this in EasyEffects upstream? Or try to find a better way as discussed [here](https://github.com/wwmm/easyeffects/issues/1089).