### PR TITLE
Switch to git source and track master branch

### DIFF
--- a/com.github.wwmm.easyeffects.yml
+++ b/com.github.wwmm.easyeffects.yml
@@ -58,14 +58,10 @@ modules:
   - name: easyeffects
     buildsystem: meson
     sources:
-      - type: archive
-        url: https://github.com/wwmm/easyeffects/archive/473cb6a985013f0e8af8136b53b27e64083ccc28.zip
-        sha256: cc8edcd8b760ee14411860e464d20ee0c96eb077d9760a9f24a9002b721f1283
-        x-checker-data:
-          type: html
-          url: https://raw.githubusercontent.com/vchernin/nightly-easyeffects-checker/main/latest_easyeffects_commit
-          version-pattern: (^.*$)
-          url-template: https://github.com/wwmm/easyeffects/archive/$version.zip
+      - type: git
+        url: https://github.com/wwmm/easyeffects.git
+        branch: master
+        commit: 473cb6a985013f0e8af8136b53b27e64083ccc28
 
       - type: file
         path: easyeffects-wrapper.sh

--- a/com.github.wwmm.easyeffects.yml
+++ b/com.github.wwmm.easyeffects.yml
@@ -60,8 +60,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/wwmm/easyeffects.git
-        branch: master
-        commit: eb6937539ab21e76aa92e2cd6727468b7adcc72c
+        branch: libadwaita
+        commit: 473cb6a985013f0e8af8136b53b27e64083ccc28
 
       - type: file
         path: easyeffects-wrapper.sh

--- a/com.github.wwmm.easyeffects.yml
+++ b/com.github.wwmm.easyeffects.yml
@@ -61,7 +61,7 @@ modules:
       - type: git
         url: https://github.com/wwmm/easyeffects.git
         branch: master
-        commit: 473cb6a985013f0e8af8136b53b27e64083ccc28
+        commit: eb6937539ab21e76aa92e2cd6727468b7adcc72c
 
       - type: file
         path: easyeffects-wrapper.sh
@@ -358,8 +358,8 @@ modules:
         cleanup:
           - /include
 
-            
-            
+
+
       - name: libportal
         buildsystem: meson
         sources:


### PR DESCRIPTION
flathub/flatpak-external-data-checker#259 has landed, f-e-d-c should now properly open PRs against the beta branch.

This patch changes easyeffects source to git, so that f-e-d-c will track master branch and update to the latest commit every time it's ran.