### PR TITLE
use calf plugins extension from flathub

### DIFF
--- a/com.github.wwmm.easyeffects.json
+++ b/com.github.wwmm.easyeffects.json
@@ -34,6 +34,14 @@
             "subdirectories": true,
             "no-autodownload": true
         },
+        "org.freedesktop.LinuxAudio.Plugins.Calf": {
+            "directory": "extensions/Plugins/Calf",
+            "version": "22.08",
+            "add-ld-path": "lib",
+            "merge-dirs": "lv2",
+            "autodelete": false,
+            "subdirectories": true
+        },
         "org.freedesktop.LinuxAudio.Plugins.LSP": {
             "directory": "extensions/Plugins/LSP",
             "version": "22.08",


### PR DESCRIPTION
related to: https://github.com/flathub/com.github.wwmm.easyeffects/issues/169

Currently this results in duplicate warnings since upstream EE still bundles the calf plugins.
EE has to be updated after this is merged:
https://github.com/wwmm/easyeffects/pull/2074
(or alternatively a temporary patch has to be created to remove calf plugins from `easyeffects/util/flatpak/easyeffects-modules.json`)