### PR TITLE
Update EasyEffect to v7.1.0

### DIFF
--- a/com.github.wwmm.easyeffects.json
+++ b/com.github.wwmm.easyeffects.json
@@ -77,8 +77,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/wwmm/easyeffects",
-                    "tag": "v7.0.8",
-                    "commit": "42e373aaf6a56b476b038730b31e8eb6f0e9dd94"
+                    "tag": "v7.1.0",
+                    "commit": "ef405d19dfc6c40aea17ac44906e26fde8892262"
                 }
             ],
             "post-install": [

--- a/easyeffects-modules.json
+++ b/easyeffects-modules.json
@@ -213,14 +213,14 @@
             "buildsystem": "meson",
             "config-opts": [
                 "-Ddocs=false",
-                "-Dbackends=gtk4"
+                "-Dbackend-gtk4=enabled"
             ],
             "sources": [
                 {
                     "type": "git",
                     "url": "https://github.com/flatpak/libportal.git",
-                    "tag": "0.6",
-                    "commit": "13df0b887a7eb7b0f9b14069561a41f62e813155",
+                    "tag": "0.7",
+                    "commit": "fcfd10af0d60b0e5e81aff1db523145a3e2e87aa",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/flatpak/libportal/releases/latest",


### PR DESCRIPTION
Most of the updates between 7.0.8 and 7.1.0 are only logic-wise udpates without dependency updates, but the handful of dependency updates will be discussed on the PR.

@vchernin I'm not too sure about this whole setup with the flatpak considering that [util/flatpak](https://github.com/wwmm/easyeffects/tree/master/util/flatpak) exists on the original repository. Does this repository need to be updated? 