### PR TITLE
Add upstream manifest link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-This is a downstream Flatpak package of [EasyEffects](https://github.com/wwmm/easyeffects). The manifest is maintained upstream.
+This is a downstream Flatpak package of [Easy Effects](https://github.com/wwmm/easyeffects). The manifest is [maintained upstream](https://github.com/wwmm/easyeffects/tree/master/util/flatpak).


### PR DESCRIPTION
But the real reason for this commit is not readme maintenance, but to retrigger a build of v8.0.3, as yesterday's builds ended up being published in the wrong order. f7e184692a3675ebaba6245844f90a894f12baf6 (v8.0.1) was published after 18f698d435537c95f997c955c960897d5cca8a47 (v8.0.3). We want v8.0.3.